### PR TITLE
select image that supports root access on emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ adb pull /data/data/com.WhatsApp/databases/wa.db
 3. [download the WhatsApp APK (any version)](https://www.apkmirror.com/apk/WhatsApp-inc/WhatsApp/)
 4. In android studio - Tools > AVD Manager
 5. Create an android virtual device (AVD)
+  - Select an image with Google APIs, but without Google Play to be able to access as `root`
 6. Start the AVD
 7. Install WhatsApp APK (drag and drop the APK file onto the virtual device) 
 8. install and activate WhatsApp on the AVD


### PR DESCRIPTION
To enable root access, pick an emulator system image that is NOT labelled "Google Play", but that support Google APIs